### PR TITLE
fix data type overflow in CAN message timestamps

### DIFF
--- a/drivers/net/can/spi/mcp25xxfd/mcp25xxfd_can.h
+++ b/drivers/net/can/spi/mcp25xxfd/mcp25xxfd_can.h
@@ -23,7 +23,7 @@ int mcp25xxfd_can_targetmode(struct mcp25xxfd_can_priv *cpriv)
 
 static inline
 void mcp25xxfd_can_queue_frame(struct mcp25xxfd_can_priv *cpriv,
-			       s32 fifo, u16 ts, bool is_rx)
+			       s32 fifo, u32 ts, bool is_rx)
 {
 	int idx = cpriv->fifos.submit_queue_count;
 


### PR DESCRIPTION
Hi,

during testing of the MCP25XXFD CAN driver I encountered some problems with the order of received CAN messages. It is caused by a data type overflow of the message timestamp value.

BR,
Harald